### PR TITLE
Implement rotation-based aim detection

### DIFF
--- a/src/main/java/com/modernac/checks/aim/AggressiveComponentCheck.java
+++ b/src/main/java/com/modernac/checks/aim/AggressiveComponentCheck.java
@@ -1,11 +1,17 @@
 package com.modernac.checks.aim;
 
 import com.modernac.player.PlayerData;
+import com.modernac.player.RotationPacket;
 import com.modernac.logging.DebugLogger;
 import com.modernac.ModernACPlugin;
 
 public class AggressiveComponentCheck extends AimCheck {
     private final DebugLogger logger;
+    private float lastYaw;
+    private float lastPitch;
+    private long lastTime;
+    private boolean initialized;
+
     public AggressiveComponentCheck(ModernACPlugin plugin, PlayerData data) {
         super(plugin, data, "Aggressive Component", false);
         this.logger = plugin.getDebugLogger();
@@ -13,10 +19,35 @@ public class AggressiveComponentCheck extends AimCheck {
 
     @Override
     public void handle(Object packet) {
-        double threshold = 5 * plugin.getConfigManager().getCombatTolerance().getMultiplier();
-        logger.log(data.getUuid() + " handled Aggressive Component");
-        if (Math.random() * 10 > threshold) {
-            fail(1, true);
+        if (!(packet instanceof RotationPacket)) {
+            return;
         }
+
+        RotationPacket rot = (RotationPacket) packet;
+        logger.log(data.getUuid() + " handled Aggressive Component");
+
+        float yaw = rot.getYaw();
+        float pitch = rot.getPitch();
+        long time = rot.getTimestamp();
+
+        if (initialized) {
+            float yawDiff = Math.abs(yaw - lastYaw);
+            float pitchDiff = Math.abs(pitch - lastPitch);
+            long deltaTime = time - lastTime;
+
+            double multiplier = plugin.getConfigManager().getCombatTolerance().getMultiplier();
+            long minInterval = (long) (50 / multiplier);
+            double yawThreshold = 30 * multiplier;
+            double pitchThreshold = 30 * multiplier;
+
+            if (deltaTime < minInterval && (yawDiff > yawThreshold || pitchDiff > pitchThreshold)) {
+                fail(1, true);
+            }
+        }
+
+        lastYaw = yaw;
+        lastPitch = pitch;
+        lastTime = time;
+        initialized = true;
     }
 }

--- a/src/main/java/com/modernac/checks/aim/SimpleHeuristicCheck.java
+++ b/src/main/java/com/modernac/checks/aim/SimpleHeuristicCheck.java
@@ -1,11 +1,17 @@
 package com.modernac.checks.aim;
 
 import com.modernac.player.PlayerData;
+import com.modernac.player.RotationPacket;
 import com.modernac.logging.DebugLogger;
 import com.modernac.ModernACPlugin;
 
 public class SimpleHeuristicCheck extends AimCheck {
     private final DebugLogger logger;
+    private float lastYaw;
+    private float lastPitch;
+    private long lastTime;
+    private boolean initialized;
+
     public SimpleHeuristicCheck(ModernACPlugin plugin, PlayerData data) {
         super(plugin, data, "Simple heuristic", false);
         this.logger = plugin.getDebugLogger();
@@ -13,9 +19,36 @@ public class SimpleHeuristicCheck extends AimCheck {
 
     @Override
     public void handle(Object packet) {
-        double threshold = 10 * plugin.getConfigManager().getCombatTolerance().getMultiplier();
-        if (Math.random() * 10 > threshold) {
-            fail(1, true);
+        if (!(packet instanceof RotationPacket)) {
+            return;
         }
+
+        RotationPacket rot = (RotationPacket) packet;
+        logger.log(data.getUuid() + " handled Simple heuristic");
+
+        float yaw = rot.getYaw();
+        float pitch = rot.getPitch();
+        long time = rot.getTimestamp();
+
+        if (initialized) {
+            float yawDiff = Math.abs(yaw - lastYaw);
+            float pitchDiff = Math.abs(pitch - lastPitch);
+            long deltaTime = time - lastTime;
+
+            if (deltaTime > 0) {
+                double multiplier = plugin.getConfigManager().getCombatTolerance().getMultiplier();
+                double speed = (yawDiff + pitchDiff) / deltaTime;
+                double speedThreshold = 2.0 * multiplier;
+
+                if (speed > speedThreshold) {
+                    fail(1, true);
+                }
+            }
+        }
+
+        lastYaw = yaw;
+        lastPitch = pitch;
+        lastTime = time;
+        initialized = true;
     }
 }

--- a/src/main/java/com/modernac/player/RotationPacket.java
+++ b/src/main/java/com/modernac/player/RotationPacket.java
@@ -1,0 +1,28 @@
+package com.modernac.player;
+
+/**
+ * Simple data holder representing a player's rotation at a moment in time.
+ */
+public class RotationPacket {
+    private final float yaw;
+    private final float pitch;
+    private final long timestamp;
+
+    public RotationPacket(float yaw, float pitch, long timestamp) {
+        this.yaw = yaw;
+        this.pitch = pitch;
+        this.timestamp = timestamp;
+    }
+
+    public float getYaw() {
+        return yaw;
+    }
+
+    public float getPitch() {
+        return pitch;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+}


### PR DESCRIPTION
## Summary
- Replace random heuristics in AggressiveComponent and SimpleHeuristic aim checks with rotation/timing analysis
- Add `RotationPacket` data holder for yaw, pitch, and timestamp

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b115b82388325b0c8b72900819e31