### PR TITLE
Integrate PacketEvents packet listener

### DIFF
--- a/src/main/java/com/modernac/ModernACPlugin.java
+++ b/src/main/java/com/modernac/ModernACPlugin.java
@@ -8,6 +8,8 @@ import com.modernac.manager.AlertManager;
 import com.modernac.manager.PunishmentManager;
 import com.modernac.messages.MessageManager;
 import com.modernac.listener.PlayerListener;
+import com.modernac.listener.PacketListener;
+import com.github.retrooper.packetevents.PacketEvents;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public class ModernACPlugin extends JavaPlugin {
@@ -20,6 +22,11 @@ public class ModernACPlugin extends JavaPlugin {
     private AlertManager alertManager;
     private PunishmentManager punishmentManager;
     private MitigationManager mitigationManager;
+
+    @Override
+    public void onLoad() {
+        PacketEvents.create(this).load();
+    }
 
     @Override
     public void onEnable() {
@@ -35,6 +42,9 @@ public class ModernACPlugin extends JavaPlugin {
 
         getServer().getPluginManager().registerEvents(new PlayerListener(this), this);
 
+        PacketEvents.getAPI().getEventManager().registerListener(new PacketListener(this));
+        PacketEvents.getAPI().init();
+
         getLogger().info("ModernAC enabled.");
     }
 
@@ -43,6 +53,7 @@ public class ModernACPlugin extends JavaPlugin {
         if (checkManager != null) {
             checkManager.shutdown();
         }
+        PacketEvents.getAPI().terminate();
         getLogger().info("ModernAC disabled.");
     }
 

--- a/src/main/java/com/modernac/listener/PacketListener.java
+++ b/src/main/java/com/modernac/listener/PacketListener.java
@@ -2,20 +2,36 @@ package com.modernac.listener;
 
 import com.modernac.ModernACPlugin;
 import com.modernac.manager.CheckManager;
+import com.github.retrooper.packetevents.event.PacketListenerAbstract;
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.protocol.packettype.PacketTypeCommon;
 import org.bukkit.entity.Player;
 
-// Placeholder PacketEvents listener
-public class PacketListener {
-    private final ModernACPlugin plugin;
+/**
+ * PacketEvents listener that forwards rotation and attack packets to the check manager.
+ */
+public class PacketListener extends PacketListenerAbstract {
     private final CheckManager manager;
 
     public PacketListener(ModernACPlugin plugin) {
-        this.plugin = plugin;
         this.manager = plugin.getCheckManager();
     }
 
-    // Example method representing packet receive
-    public void onRotationPacket(Player player, Object packet) {
-        manager.handle(player.getUniqueId(), packet);
+    @Override
+    public void onPacketReceive(PacketReceiveEvent event) {
+        Object obj = event.getPlayer();
+        if (!(obj instanceof Player)) {
+            return;
+        }
+        Player player = (Player) obj;
+        PacketTypeCommon type = event.getPacketType();
+        if (type == PacketType.Play.Client.LOOK
+                || type == PacketType.Play.Client.POSITION
+                || type == PacketType.Play.Client.POSITION_LOOK
+                || type == PacketType.Play.Client.USE_ENTITY
+                || type == PacketType.Play.Client.ANIMATION) {
+            manager.handle(player.getUniqueId(), event.getPacket());
+        }
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,3 +3,4 @@ main: com.modernac.ModernACPlugin
 version: 0.1.0
 api-version: 1.16
 commands: {}
+depend: [packetevents]


### PR DESCRIPTION
## Summary
- Replace placeholder packet listener with PacketEvents implementation
- Hook PacketEvents into plugin lifecycle and register listener on enable
- Declare PacketEvents as dependency in plugin.yml

## Testing
- `mvn -q -e test` *(fails: Could not transfer maven-resources-plugin due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b115f3e8083259f6f4807d737dd8e