### PR TITLE
Use event handlers for combat checks

### DIFF
--- a/src/main/java/com/modernac/ModernACPlugin.java
+++ b/src/main/java/com/modernac/ModernACPlugin.java
@@ -8,6 +8,7 @@ import com.modernac.manager.AlertManager;
 import com.modernac.manager.PunishmentManager;
 import com.modernac.messages.MessageManager;
 import com.modernac.listener.PlayerListener;
+import com.modernac.listener.CombatListener;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public class ModernACPlugin extends JavaPlugin {
@@ -34,6 +35,7 @@ public class ModernACPlugin extends JavaPlugin {
         this.mitigationManager = new MitigationManager(this);
 
         getServer().getPluginManager().registerEvents(new PlayerListener(this), this);
+        getServer().getPluginManager().registerEvents(new CombatListener(this), this);
 
         getLogger().info("ModernAC enabled.");
     }

--- a/src/main/java/com/modernac/checks/misc/AutoTotemCheck.java
+++ b/src/main/java/com/modernac/checks/misc/AutoTotemCheck.java
@@ -2,6 +2,7 @@ package com.modernac.checks.misc;
 
 import com.modernac.ModernACPlugin;
 import com.modernac.checks.Check;
+import com.modernac.events.TotemPopEventData;
 import com.modernac.player.PlayerData;
 
 public class AutoTotemCheck extends Check {
@@ -10,7 +11,9 @@ public class AutoTotemCheck extends Check {
     }
 
     @Override
-    public void handle(Object packet) {
-        // TODO: Autototem heuristic detection
+    public void handle(Object data) {
+        if (data instanceof TotemPopEventData) {
+            // TODO: Autototem heuristic detection
+        }
     }
 }

--- a/src/main/java/com/modernac/checks/misc/TriggerBotCheck.java
+++ b/src/main/java/com/modernac/checks/misc/TriggerBotCheck.java
@@ -2,6 +2,7 @@ package com.modernac.checks.misc;
 
 import com.modernac.ModernACPlugin;
 import com.modernac.checks.Check;
+import com.modernac.events.AttackEventData;
 import com.modernac.player.PlayerData;
 
 public class TriggerBotCheck extends Check {
@@ -10,7 +11,9 @@ public class TriggerBotCheck extends Check {
     }
 
     @Override
-    public void handle(Object packet) {
-        // TODO: Trigger-bot detection
+    public void handle(Object data) {
+        if (data instanceof AttackEventData) {
+            // TODO: Trigger-bot detection
+        }
     }
 }

--- a/src/main/java/com/modernac/events/AttackEventData.java
+++ b/src/main/java/com/modernac/events/AttackEventData.java
@@ -1,0 +1,5 @@
+package com.modernac.events;
+
+import java.util.UUID;
+
+public record AttackEventData(UUID attackerId, UUID victimId) {}

--- a/src/main/java/com/modernac/events/TotemPopEventData.java
+++ b/src/main/java/com/modernac/events/TotemPopEventData.java
@@ -1,0 +1,5 @@
+package com.modernac.events;
+
+import java.util.UUID;
+
+public record TotemPopEventData(UUID playerId) {}

--- a/src/main/java/com/modernac/listener/CombatListener.java
+++ b/src/main/java/com/modernac/listener/CombatListener.java
@@ -1,0 +1,32 @@
+package com.modernac.listener;
+
+import com.modernac.ModernACPlugin;
+import com.modernac.events.AttackEventData;
+import com.modernac.events.TotemPopEventData;
+import com.modernac.manager.CheckManager;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityResurrectEvent;
+
+public class CombatListener implements Listener {
+    private final CheckManager manager;
+
+    public CombatListener(ModernACPlugin plugin) {
+        this.manager = plugin.getCheckManager();
+    }
+
+    @EventHandler
+    public void onTotemPop(EntityResurrectEvent event) {
+        if (!(event.getEntity() instanceof Player player)) return;
+        manager.handle(player.getUniqueId(), new TotemPopEventData(player.getUniqueId()));
+    }
+
+    @EventHandler
+    public void onDamage(EntityDamageByEntityEvent event) {
+        if (!(event.getDamager() instanceof Player attacker)) return;
+        if (!(event.getEntity() instanceof Player victim)) return;
+        manager.handle(attacker.getUniqueId(), new AttackEventData(attacker.getUniqueId(), victim.getUniqueId()));
+    }
+}

--- a/src/main/java/com/modernac/manager/CheckManager.java
+++ b/src/main/java/com/modernac/manager/CheckManager.java
@@ -33,14 +33,14 @@ public class CheckManager {
         checks.remove(uuid);
     }
 
-    public void handle(UUID uuid, Object packet) {
+    public void handle(UUID uuid, Object data) {
         List<Check> list = checks.get(uuid);
         if (list == null) {
             return;
         }
         executor.execute(() -> {
             for (Check check : list) {
-                check.handle(packet);
+                check.handle(data);
             }
         });
     }


### PR DESCRIPTION
## Summary
- Add CombatListener for EntityResurrectEvent and EntityDamageByEntityEvent and dispatch structured combat data
- Introduce simple data records for totem pops and attack events
- Update CheckManager and related checks to handle structured event data

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b116289908325901b42bb4fc362b4