### PR TITLE
Improve mitigation handling

### DIFF
--- a/src/main/java/com/modernac/manager/MitigationManager.java
+++ b/src/main/java/com/modernac/manager/MitigationManager.java
@@ -5,14 +5,20 @@ import org.bukkit.Bukkit;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitTask;
 
 import java.util.Map;
+import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class MitigationManager {
     private final ModernACPlugin plugin;
     private final Map<UUID, Integer> mitigated = new ConcurrentHashMap<>();
+    private final Map<UUID, Double> baseValues = new ConcurrentHashMap<>();
+    private final Map<UUID, BukkitTask> applyTasks = new ConcurrentHashMap<>();
+    private final Map<UUID, BukkitTask> removeTasks = new ConcurrentHashMap<>();
+    private final Random random = new Random();
 
     public MitigationManager(ModernACPlugin plugin) {
         this.plugin = plugin;
@@ -20,9 +26,25 @@ public class MitigationManager {
 
     public void mitigate(UUID uuid, int level) {
         mitigated.put(uuid, level);
+
+        // schedule application after random delay (5-15s) on main thread
+        BukkitTask oldApply = applyTasks.remove(uuid);
+        if (oldApply != null) oldApply.cancel();
+        long applyDelay = 20L * (5 + random.nextInt(11));
+        BukkitTask applyTask = Bukkit.getScheduler().runTaskLater(plugin, () -> apply(uuid), applyDelay);
+        applyTasks.put(uuid, applyTask);
+
+        // schedule removal after configured duration and restore base value
+        BukkitTask oldRemove = removeTasks.remove(uuid);
+        if (oldRemove != null) oldRemove.cancel();
         long duration = 20L * plugin.getConfigManager().getMitigationDurationSeconds();
-        Bukkit.getScheduler().runTaskLater(plugin, () -> mitigated.remove(uuid), duration);
-        apply(uuid);
+        BukkitTask removeTask = Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            mitigated.remove(uuid);
+            baseValues.remove(uuid);
+            apply(uuid); // restore base
+            removeTasks.remove(uuid);
+        }, duration);
+        removeTasks.put(uuid, removeTask);
     }
 
     private void apply(UUID uuid) {
@@ -30,8 +52,10 @@ public class MitigationManager {
         if (player == null) return;
         AttributeInstance attr = player.getAttribute(Attribute.GENERIC_ATTACK_DAMAGE);
         if (attr == null) return;
-        double base = attr.getBaseValue();
-        double modifier = base * (1 - mitigated.getOrDefault(uuid, 0) / 100.0);
+        baseValues.computeIfAbsent(uuid, k -> attr.getBaseValue());
+        double base = baseValues.get(uuid);
+        int level = mitigated.getOrDefault(uuid, 0);
+        double modifier = base * (1 - level / 100.0);
         attr.setBaseValue(modifier);
     }
 }

--- a/src/main/java/com/modernac/manager/MitigationManager.java
+++ b/src/main/java/com/modernac/manager/MitigationManager.java
@@ -5,7 +5,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitTask;
 
 import java.util.Map;
 import java.util.Random;
@@ -16,8 +15,8 @@ public class MitigationManager {
     private final ModernACPlugin plugin;
     private final Map<UUID, Integer> mitigated = new ConcurrentHashMap<>();
     private final Map<UUID, Double> baseValues = new ConcurrentHashMap<>();
-    private final Map<UUID, BukkitTask> applyTasks = new ConcurrentHashMap<>();
-    private final Map<UUID, BukkitTask> removeTasks = new ConcurrentHashMap<>();
+    private final Map<UUID, Integer> applyTasks = new ConcurrentHashMap<>();
+    private final Map<UUID, Integer> removeTasks = new ConcurrentHashMap<>();
     private final Random random = new Random();
 
     public MitigationManager(ModernACPlugin plugin) {
@@ -28,20 +27,26 @@ public class MitigationManager {
         mitigated.put(uuid, level);
 
         // schedule application after random delay (5-15s) on main thread
-        BukkitTask oldApply = applyTasks.remove(uuid);
-        if (oldApply != null) oldApply.cancel();
+        Integer oldApply = applyTasks.remove(uuid);
+        if (oldApply != null) Bukkit.getScheduler().cancelTask(oldApply);
         long applyDelay = 20L * (5 + random.nextInt(11));
-        BukkitTask applyTask = Bukkit.getScheduler().runTaskLater(plugin, () -> apply(uuid), applyDelay);
+        int applyTask = Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, () -> apply(uuid), applyDelay);
         applyTasks.put(uuid, applyTask);
 
         // schedule removal after configured duration and restore base value
-        BukkitTask oldRemove = removeTasks.remove(uuid);
-        if (oldRemove != null) oldRemove.cancel();
+        Integer oldRemove = removeTasks.remove(uuid);
+        if (oldRemove != null) Bukkit.getScheduler().cancelTask(oldRemove);
         long duration = 20L * plugin.getConfigManager().getMitigationDurationSeconds();
-        BukkitTask removeTask = Bukkit.getScheduler().runTaskLater(plugin, () -> {
+        int removeTask = Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, () -> {
             mitigated.remove(uuid);
-            baseValues.remove(uuid);
-            apply(uuid); // restore base
+            Double base = baseValues.remove(uuid);
+            Player player = Bukkit.getPlayer(uuid);
+            if (player != null) {
+                AttributeInstance attr = player.getAttribute(Attribute.GENERIC_ATTACK_DAMAGE);
+                if (attr != null && base != null) {
+                    attr.setBaseValue(base);
+                }
+            }
             removeTasks.remove(uuid);
         }, duration);
         removeTasks.put(uuid, removeTask);

--- a/src/main/java/org/bukkit/scheduler/BukkitScheduler.java
+++ b/src/main/java/org/bukkit/scheduler/BukkitScheduler.java
@@ -1,6 +1,20 @@
 package org.bukkit.scheduler;
 
 public class BukkitScheduler {
-    public void runTaskLater(Object plugin, Runnable task, long delay) { task.run(); }
-    public void runTaskLaterAsynchronously(Object plugin, Runnable task, long delay) { task.run(); }
+    public BukkitTask runTaskLater(Object plugin, Runnable task, long delay) {
+        task.run();
+        return new DummyBukkitTask();
+    }
+
+    public BukkitTask runTaskLaterAsynchronously(Object plugin, Runnable task, long delay) {
+        task.run();
+        return new DummyBukkitTask();
+    }
+
+    private static class DummyBukkitTask implements BukkitTask {
+        @Override
+        public void cancel() {
+            // no-op
+        }
+    }
 }

--- a/src/main/java/org/bukkit/scheduler/BukkitTask.java
+++ b/src/main/java/org/bukkit/scheduler/BukkitTask.java
@@ -1,0 +1,6 @@
+package org.bukkit.scheduler;
+
+public interface BukkitTask {
+    void cancel();
+}
+


### PR DESCRIPTION
## Summary
- delay combat mitigation 5-15s and run on main thread
- restore original attack damage when mitigation expires

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:2.6 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b2000acc483259aa1201e0009cba2