### PR TITLE
Fix PluginManager stub to align with Bukkit API

### DIFF
--- a/src/main/java/org/bukkit/plugin/Plugin.java
+++ b/src/main/java/org/bukkit/plugin/Plugin.java
@@ -1,0 +1,9 @@
+package org.bukkit.plugin;
+
+/**
+ * Marker interface mirroring Bukkit's {@code Plugin}. The actual server will
+ * provide a complete implementation at runtime.
+ */
+public interface Plugin {
+}
+

--- a/src/main/java/org/bukkit/plugin/PluginManager.java
+++ b/src/main/java/org/bukkit/plugin/PluginManager.java
@@ -1,8 +1,14 @@
 package org.bukkit.plugin;
 
 import org.bukkit.event.Listener;
-import org.bukkit.plugin.java.JavaPlugin;
 
+/**
+ * Minimal representation of Bukkit's {@code PluginManager} used for
+ * compilation. The runtime server provides the real implementation.
+ */
 public interface PluginManager {
-    void registerEvents(Listener listener, JavaPlugin plugin);
+    /**
+     * Register an event listener with the given plugin.
+     */
+    void registerEvents(Listener listener, Plugin plugin);
 }

--- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
@@ -5,8 +5,13 @@ import java.util.logging.Logger;
 
 import org.bukkit.Server;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.plugin.Plugin;
 
-public class JavaPlugin {
+/**
+ * Simplified stand-in for Bukkit's {@code JavaPlugin}. It implements the
+ * {@link Plugin} marker so code depending on the interface can compile.
+ */
+public class JavaPlugin implements Plugin {
     private final FileConfiguration config = new FileConfiguration();
 
     public void saveDefaultConfig() {}


### PR DESCRIPTION
## Summary
- Update PluginManager stub to accept `Plugin` rather than `JavaPlugin`
- Introduce minimal `Plugin` interface and implement it in stub `JavaPlugin`

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:2.6 - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b33ee234083259b9f7416a4f4cbf1