### PR TITLE
Fix scheduler stub for plugin compatibility

### DIFF
--- a/src/main/java/org/bukkit/Bukkit.java
+++ b/src/main/java/org/bukkit/Bukkit.java
@@ -8,9 +8,10 @@ import java.nio.charset.StandardCharsets;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitScheduler;
+import org.bukkit.scheduler.DummyBukkitScheduler;
 
 public class Bukkit {
-    private static final BukkitScheduler scheduler = new BukkitScheduler();
+    private static final BukkitScheduler scheduler = new DummyBukkitScheduler();
 
     public static BukkitScheduler getScheduler() { return scheduler; }
 

--- a/src/main/java/org/bukkit/scheduler/BukkitScheduler.java
+++ b/src/main/java/org/bukkit/scheduler/BukkitScheduler.java
@@ -1,29 +1,24 @@
 package org.bukkit.scheduler;
 
-public class BukkitScheduler {
-    public BukkitTask runTaskLater(Object plugin, Runnable task, long delay) {
-        task.run();
-        return new DummyBukkitTask();
-    }
+/**
+ * Minimal scheduler interface used for testing without a real Bukkit runtime.
+ *
+ * <p>This mirrors the Bukkit API's {@code BukkitScheduler} which is an
+ * interface on modern servers. The previous stub incorrectly declared it as a
+ * class which caused code compiled against it to expect a concrete class at
+ * runtime. When running on a real server the scheduler is provided as an
+ * interface, leading to {@link java.lang.IncompatibleClassChangeError}. By
+ * modelling it as an interface here we ensure the compiled bytecode matches the
+ * actual API.</p>
+ */
+public interface BukkitScheduler {
 
-    public BukkitTask runTaskLaterAsynchronously(Object plugin, Runnable task, long delay) {
-        task.run();
-        return new DummyBukkitTask();
-    }
+    BukkitTask runTaskLater(Object plugin, Runnable task, long delay);
 
-    public int scheduleSyncRepeatingTask(Object plugin, Runnable task, long delay, long period) {
-        task.run();
-        return 0;
-    }
+    BukkitTask runTaskLaterAsynchronously(Object plugin, Runnable task, long delay);
 
-    public void cancelTask(int id) {
-        // no-op
-    }
+    int scheduleSyncRepeatingTask(Object plugin, Runnable task, long delay, long period);
 
-    private static class DummyBukkitTask implements BukkitTask {
-        @Override
-        public void cancel() {
-            // no-op
-        }
-    }
+    void cancelTask(int id);
 }
+

--- a/src/main/java/org/bukkit/scheduler/DummyBukkitScheduler.java
+++ b/src/main/java/org/bukkit/scheduler/DummyBukkitScheduler.java
@@ -1,0 +1,37 @@
+package org.bukkit.scheduler;
+
+/**
+ * Simple no-op scheduler implementation used for testing. Tasks are executed
+ * immediately on the calling thread and no scheduling actually occurs.
+ */
+public class DummyBukkitScheduler implements BukkitScheduler {
+    @Override
+    public BukkitTask runTaskLater(Object plugin, Runnable task, long delay) {
+        task.run();
+        return new DummyBukkitTask();
+    }
+
+    @Override
+    public BukkitTask runTaskLaterAsynchronously(Object plugin, Runnable task, long delay) {
+        task.run();
+        return new DummyBukkitTask();
+    }
+
+    @Override
+    public int scheduleSyncRepeatingTask(Object plugin, Runnable task, long delay, long period) {
+        task.run();
+        return 0;
+    }
+
+    @Override
+    public void cancelTask(int id) {
+        // no-op
+    }
+
+    private static class DummyBukkitTask implements BukkitTask {
+        @Override
+        public void cancel() {
+            // no-op
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- replace BukkitScheduler stub class with interface matching Bukkit API
- add DummyBukkitScheduler implementation and wire it into Bukkit stub

## Testing
- `mvn -q -e package` *(fails: Could not transfer artifact maven-resources-plugin:2.6, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b54ee7dcc83258116924cb3643273