### PR TITLE
Fix PacketEvents builder import

### DIFF
--- a/src/main/java/com/modernac/ModernACPlugin.java
+++ b/src/main/java/com/modernac/ModernACPlugin.java
@@ -13,7 +13,7 @@ import com.modernac.manager.ExemptManager;
 import com.modernac.manager.MitigationManager;
 import com.modernac.manager.PunishmentManager;
 import com.modernac.messages.MessageManager;
-import io.github.retrooper.packetevents.factory.spigot.SpigotPacketEventsBuilder;
+import com.github.retrooper.packetevents.factory.spigot.SpigotPacketEventsBuilder;
 import java.util.UUID;
 import org.bukkit.plugin.java.JavaPlugin;
 


### PR DESCRIPTION
## Summary
- use com.github SpigotPacketEventsBuilder to match PacketEvents 2.9.x package

## Testing
- `rg -n -P "^package (org\\.bukkit|net\\.md_5|io\\.github\\.retrooper|com\\.github\\.retrooper)(?=\\.)" src/main/java || true`
- `rg -n "io\\.github\\.retrooper\\.packetevents" src/main/java || true`
- `rg -n "^main: com\\.modernac\\.ModernACPlugin" src/main/resources/plugin.yml`
- `rg -n "^depend: \[packetevents\]" src/main/resources/plugin.yml`
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689c5cbbd7dc83258cc95184cb6d30e9