### PR TITLE
Harden async detector runner and snapshot aim windows

### DIFF
--- a/src/main/java/com/modernac/checks/aim/DistinctCheck.java
+++ b/src/main/java/com/modernac/checks/aim/DistinctCheck.java
@@ -3,6 +3,9 @@ package com.modernac.checks.aim;
 import com.modernac.ModernACPlugin;
 import com.modernac.player.PlayerData;
 import com.modernac.player.RotationData;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
 
 public class DistinctCheck extends AimCheck {
 
@@ -10,24 +13,61 @@ public class DistinctCheck extends AimCheck {
     super(plugin, data, "Distinct", false);
   }
 
-  private final java.util.Deque<Double> lastYaw = new java.util.ArrayDeque<>();
+  private static final int MIN_SAMPLES = 10;
+  private static final double EPS = 1e-6;
+
+  private final Deque<Double> lastYaw = new ArrayDeque<>();
+
+  private static double[] snapshotNonNull(Deque<Double> q) {
+    Double[] tmp;
+    synchronized (q) {
+      tmp = q.toArray(new Double[0]);
+    }
+    double[] out = new double[tmp.length];
+    int n = 0;
+    for (Double d : tmp) {
+      if (d != null) {
+        double v = d.doubleValue();
+        if (!Double.isNaN(v) && !Double.isInfinite(v)) out[n++] = v;
+      }
+    }
+    return n == out.length ? out : Arrays.copyOf(out, n);
+  }
 
   @Override
   public void handle(Object packet) {
     if (!(packet instanceof RotationData)) {
       return;
     }
-    RotationData rot = (RotationData) packet;
-    trace("handled Distinct");
-    lastYaw.add(rot.getYawChange());
-    if (lastYaw.size() > 10) {
-      lastYaw.pollFirst();
+    if (data == null) {
+      return;
     }
-    if (lastYaw.size() == 10) {
-      long distinct = lastYaw.stream().distinct().count();
-      if (distinct <= 2) {
-        fail(1, true);
+    RotationData rot = (RotationData) packet;
+    double yaw = rot.getYawChange();
+    if (!Double.isFinite(yaw)) {
+      return;
+    }
+    synchronized (lastYaw) {
+      if (lastYaw.size() >= MIN_SAMPLES) {
+        lastYaw.pollFirst();
       }
+      lastYaw.addLast(yaw);
+    }
+    double[] arr = snapshotNonNull(lastYaw);
+    if (arr.length < MIN_SAMPLES) {
+      return;
+    }
+    Arrays.sort(arr);
+    int distinct = 0;
+    double prev = Double.NaN;
+    for (double v : arr) {
+      if (distinct == 0 || Math.abs(v - prev) > EPS) {
+        distinct++;
+        prev = v;
+      }
+    }
+    if (distinct <= 2) {
+      fail(1, true);
     }
   }
 }

--- a/src/main/java/com/modernac/checks/aim/RankCheck.java
+++ b/src/main/java/com/modernac/checks/aim/RankCheck.java
@@ -3,9 +3,9 @@ package com.modernac.checks.aim;
 import com.modernac.ModernACPlugin;
 import com.modernac.player.PlayerData;
 import com.modernac.player.RotationData;
-import java.util.Deque;
 import java.util.ArrayDeque;
 import java.util.Arrays;
+import java.util.Deque;
 
 public class RankCheck extends AimCheck {
 

--- a/src/main/java/com/modernac/checks/aim/RankCheck.java
+++ b/src/main/java/com/modernac/checks/aim/RankCheck.java
@@ -3,6 +3,9 @@ package com.modernac.checks.aim;
 import com.modernac.ModernACPlugin;
 import com.modernac.player.PlayerData;
 import com.modernac.player.RotationData;
+import java.util.Deque;
+import java.util.ArrayDeque;
+import java.util.Arrays;
 
 public class RankCheck extends AimCheck {
 
@@ -10,26 +13,53 @@ public class RankCheck extends AimCheck {
     super(plugin, data, "Rank", false);
   }
 
-  private final java.util.Deque<Double> samples = new java.util.ArrayDeque<>();
+  private static final int MIN_SAMPLES = 50;
+
+  private final Deque<Double> samples = new ArrayDeque<>();
+
+  private static double[] snapshotNonNull(Deque<Double> q) {
+    Double[] tmp;
+    synchronized (q) {
+      tmp = q.toArray(new Double[0]);
+    }
+    double[] out = new double[tmp.length];
+    int n = 0;
+    for (Double d : tmp) {
+      if (d != null) {
+        double v = d.doubleValue();
+        if (!Double.isNaN(v) && !Double.isInfinite(v)) out[n++] = v;
+      }
+    }
+    return n == out.length ? out : Arrays.copyOf(out, n);
+  }
 
   @Override
   public void handle(Object packet) {
     if (!(packet instanceof RotationData)) {
       return;
     }
-    RotationData rot = (RotationData) packet;
-    trace("handled Rank");
-    samples.add(rot.getYawChange());
-    if (samples.size() > 50) {
-      samples.pollFirst();
+    if (data == null) {
+      return;
     }
-    if (samples.size() == 50) {
-      java.util.List<Double> sorted =
-          samples.stream().sorted().collect(java.util.stream.Collectors.toList());
-      int index = sorted.indexOf(rot.getYawChange());
-      if (index == 0 || index == sorted.size() - 1) {
-        fail(1, true);
+    RotationData rot = (RotationData) packet;
+    double yaw = rot.getYawChange();
+    if (!Double.isFinite(yaw)) {
+      return;
+    }
+    synchronized (samples) {
+      if (samples.size() >= MIN_SAMPLES) {
+        samples.pollFirst();
       }
+      samples.addLast(yaw);
+    }
+    double[] arr = snapshotNonNull(samples);
+    if (arr.length < MIN_SAMPLES) {
+      return;
+    }
+    Arrays.sort(arr);
+    int index = Arrays.binarySearch(arr, yaw);
+    if (index <= 0 || index >= arr.length - 1) {
+      fail(1, true);
     }
   }
 }

--- a/src/main/java/com/modernac/engine/AlertEngine.java
+++ b/src/main/java/com/modernac/engine/AlertEngine.java
@@ -143,13 +143,11 @@ public class AlertEngine {
         }
         plugin
             .getDetectionLogger()
-            .alert(
+            .trace(
                 playerId,
                 families,
                 "windows="
                     + windows
-                    + ", conf="
-                    + String.format(Locale.US, "%.1f", conf)
                     + ", ping="
                     + sample.ping
                     + ", tps="

--- a/src/main/java/com/modernac/logging/DetectionLogger.java
+++ b/src/main/java/com/modernac/logging/DetectionLogger.java
@@ -18,6 +18,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 import org.bukkit.Bukkit;
 
 /** Centralized logging for detections and alerts. */
@@ -139,6 +140,18 @@ public class DetectionLogger {
     }
     if (alertsToConsole) {
       logConsole(line);
+    }
+  }
+
+  public void error(String message) {
+    error(message, null);
+  }
+
+  public void error(String message, Throwable t) {
+    plugin.getLogger().log(Level.SEVERE, message, t);
+    String line = format.format(new Date()) + " [ERROR] " + message;
+    if (alertsToFile) {
+      writeAsync(alertFile, line);
     }
   }
 

--- a/src/main/java/com/modernac/manager/CheckManager.java
+++ b/src/main/java/com/modernac/manager/CheckManager.java
@@ -42,8 +42,7 @@ public class CheckManager {
           @Override
           public Thread newThread(Runnable r) {
             Thread t = new Thread(r, "ModernAC-detector-" + idx.incrementAndGet());
-            t.setUncaughtExceptionHandler(
-                (th, ex) -> logger.error("Detector thread failure", ex));
+            t.setUncaughtExceptionHandler((th, ex) -> logger.error("Detector thread failure", ex));
             t.setDaemon(true);
             return t;
           }
@@ -98,9 +97,7 @@ public class CheckManager {
             try {
               check.handle(packet);
             } catch (Throwable t) {
-              plugin
-                  .getDetectionLogger()
-                  .error("Exception in " + check.getName() + ".handle", t);
+              plugin.getDetectionLogger().error("Exception in " + check.getName() + ".handle", t);
             }
           }
         });

--- a/src/main/java/com/modernac/manager/CheckManager.java
+++ b/src/main/java/com/modernac/manager/CheckManager.java
@@ -7,21 +7,63 @@ import com.modernac.checks.combat.CombatCheckFactory;
 import com.modernac.checks.latency.LatencyCheckFactory;
 import com.modernac.checks.misc.MiscCheckFactory;
 import com.modernac.checks.signatures.SignatureCheckFactory;
+import com.modernac.logging.DetectionLogger;
 import com.modernac.player.PlayerData;
 import com.modernac.player.RotationData;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class CheckManager {
+  private static final int QUEUE_LIMIT = 256;
+  private static final long OVERLOAD_LOG_INTERVAL_MS = 10_000L;
+
   private final ModernACPlugin plugin;
   private final Map<UUID, List<Check>> checks = new ConcurrentHashMap<>();
   private final Map<UUID, PlayerData> players = new ConcurrentHashMap<>();
-  private final ExecutorService executor = Executors.newFixedThreadPool(2);
+  private final ThreadPoolExecutor executor;
+  private final AtomicLong lastOverloadLog = new AtomicLong();
 
   public CheckManager(ModernACPlugin plugin) {
     this.plugin = plugin;
+    DetectionLogger logger = plugin.getDetectionLogger();
+    ThreadFactory factory =
+        new ThreadFactory() {
+          private final AtomicInteger idx = new AtomicInteger();
+
+          @Override
+          public Thread newThread(Runnable r) {
+            Thread t = new Thread(r, "ModernAC-detector-" + idx.incrementAndGet());
+            t.setUncaughtExceptionHandler(
+                (th, ex) -> logger.error("Detector thread failure", ex));
+            t.setDaemon(true);
+            return t;
+          }
+        };
+    this.executor =
+        new ThreadPoolExecutor(
+            2,
+            2,
+            0L,
+            TimeUnit.MILLISECONDS,
+            new LinkedBlockingQueue<>(QUEUE_LIMIT),
+            factory,
+            (r, e) -> {
+              long now = System.currentTimeMillis();
+              long last = lastOverloadLog.get();
+              if (now - last > OVERLOAD_LOG_INTERVAL_MS
+                  && lastOverloadLog.compareAndSet(last, now)) {
+                logger.error("Detector queue overloaded, dropping tasks");
+              }
+            });
   }
 
   public void initPlayer(UUID uuid) {
@@ -53,7 +95,13 @@ public class CheckManager {
     executor.execute(
         () -> {
           for (Check check : list) {
-            check.handle(packet);
+            try {
+              check.handle(packet);
+            } catch (Throwable t) {
+              plugin
+                  .getDetectionLogger()
+                  .error("Exception in " + check.getName() + ".handle", t);
+            }
           }
         });
   }


### PR DESCRIPTION
## Summary
- add bounded detector thread pool with custom thread names, safe discard policy and error logging
- refactor RankCheck and DistinctCheck to work on finite array snapshots and avoid concurrent modification
- demote legacy detection log to trace and remove numeric confidence

## Testing
- `rg --pcre2 -n "^package (org\.bukkit|net\.md_5|io\.github\.retrooper|com\.github\.retrooper)(?=\.)" src/main/java || true`
- `rg --pcre2 -n 'import\s+io\.github\.retrooper\.packetevents\.(?!factory\.spigot\.SpigotPacketEventsBuilder)' src/main/java || true`
- `rg -n "import\s+io\.github\.retrooper\.packetevents\.factory\.spigot\.SpigotPacketEventsBuilder;" src/main/java`
- `rg -n "^main: com\.modernac\.ModernACPlugin" src/main/resources/plugin.yml`
- `rg -n "^depend: \[packetevents\]" src/main/resources/plugin.yml`
- `mvn -q spotless:apply` *(fails: No plugin found for prefix 'spotless')*
- `mvn -q -e compile` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ce14041f48325a2f0f049f9563c74