### PR TITLE
Ensure alerts for punishable outcomes

### DIFF
--- a/src/main/java/com/modernac/engine/AlertEngine.java
+++ b/src/main/java/com/modernac/engine/AlertEngine.java
@@ -58,9 +58,6 @@ public class AlertEngine {
   }
 
   public void enqueue(UUID uuid, AlertDetail detail, boolean critical) {
-    if (detail.tier != PunishmentTier.HIGH && detail.tier != PunishmentTier.CRITICAL) {
-      return;
-    }
     long now = System.currentTimeMillis();
     detail.created = now;
     if (critical && criticalFirst.add(uuid)) {
@@ -137,16 +134,6 @@ public class AlertEngine {
           }
         }
         if (batch.isEmpty()) {
-          continue;
-        }
-        boolean eligible = false;
-        for (AlertDetail d : batch) {
-          if (d.tier == PunishmentTier.HIGH || d.tier == PunishmentTier.CRITICAL) {
-            eligible = true;
-            break;
-          }
-        }
-        if (!eligible) {
           continue;
         }
         lastSent.put(playerId, now);

--- a/src/main/java/com/modernac/engine/DetectionEngine.java
+++ b/src/main/java/com/modernac/engine/DetectionEngine.java
@@ -60,8 +60,15 @@ public class DetectionEngine {
       tps = tpsArr[0];
     }
     EvalOutcome outcome = evaluate(uuid, record, ping, tps);
-    if (outcome.highest == PunishmentTier.HIGH || outcome.highest == PunishmentTier.CRITICAL) {
-      double conf = (outcome.highest == PunishmentTier.CRITICAL) ? 1.0 : 0.9;
+    boolean alertEligible =
+        outcome.punish
+            || outcome.highest == PunishmentTier.HIGH
+            || outcome.highest == PunishmentTier.CRITICAL;
+    if (alertEligible) {
+      double conf =
+          outcome.highest == PunishmentTier.CRITICAL
+              ? 1.0
+              : (outcome.highest == PunishmentTier.HIGH ? 0.9 : 0.75);
       AlertDetail detail =
           new AlertDetail(
               result.getFamily(),


### PR DESCRIPTION
## Summary
- Emit alerts whenever an outcome is punishable, even if soft conditions lower it to MEDIUM
- Allow AlertEngine to accept MEDIUM tier details so punish-triggered alerts reach staff

## Testing
- `mvn -o -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Cannot access central in offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_689d959075d4832584e4153f918f4851