### PR TITLE
Fix plugin version logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,24 @@
         </dependency>
     </dependencies>
      <build>
+        <resources>
+            <!-- Фильтруем только plugin.yml, чтобы ${project.version} подставлялся -->
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>plugin.yml</include>
+                </includes>
+            </resource>
+            <!-- Остальные ресурсы без фильтрации -->
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+                <excludes>
+                    <exclude>plugin.yml</exclude>
+                </excludes>
+            </resource>
+        </resources>
          <plugins>
              <plugin>
                  <groupId>org.apache.maven.plugins</groupId>
@@ -85,6 +103,18 @@
                 <version>4.8.3.0</version>
                 <configuration>
                     <failOnError>false</failOnError>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Implementation-Version>${project.version}</Implementation-Version>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
          </plugins>

--- a/src/main/java/com/modernac/ModernACPlugin.java
+++ b/src/main/java/com/modernac/ModernACPlugin.java
@@ -68,8 +68,18 @@ public class ModernACPlugin extends JavaPlugin {
       getLogger().severe("/ac command not defined in plugin.yml");
     }
 
+    String ver = getDescription().getVersion();
+    if (ver == null || ver.contains("${")) {
+      String manifestVer = getClass().getPackage().getImplementationVersion();
+      if (manifestVer != null) {
+        ver = manifestVer;
+      }
+      getLogger().warning(
+          "Project version was not filtered into plugin.yml; using DEV fallback.");
+    }
+    final String displayVer = ver != null ? ver : "DEV";
     detectionLogger.logStartup();
-    getLogger().info("ModernAC enabled.");
+    getLogger().info(() -> "[ModernAC] Enabling ModernAC v" + displayVer);
   }
 
   @Override


### PR DESCRIPTION
## Summary
- filter plugin.yml during build and add Implementation-Version manifest entry
- log resolved version at startup with fallback when filtering fails

## Testing
- `mvn -q -ntp -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_689d973e4e3c8325b588055a3628eb6c