### PR TITLE
Add latency guard and config fallbacks

### DIFF
--- a/src/main/java/com/modernac/commands/AcCommand.java
+++ b/src/main/java/com/modernac/commands/AcCommand.java
@@ -1,7 +1,9 @@
 package com.modernac.commands;
 
 import com.modernac.ModernACPlugin;
+import com.modernac.config.ConfigManager;
 import com.modernac.manager.PunishmentTier;
+import com.modernac.util.LatencyGuard;
 import com.modernac.util.TimeUtil;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -63,8 +65,10 @@ public class AcCommand implements CommandExecutor, TabCompleter {
         long ttl = plugin.getExemptManager().getRemaining(target.getUniqueId());
         com.modernac.engine.DetectionEngine.DetectionSummary sum =
             plugin.getDetectionEngine().getSummary(target.getUniqueId());
-        boolean latencyOK = sum != null && sum.latencyOK;
-        boolean stabilityOK = sum != null && sum.stabilityOK;
+        ConfigManager cfg = plugin.getConfigManager();
+        int limit = cfg.getUnstableConnectionLimit();
+        double tpsGuard = cfg.getTpsSoftGuard();
+        boolean stable = ping > 0 && LatencyGuard.isStable(ping, tps, limit, tpsGuard);
         double shortW = sum != null ? sum.shortWindow : 0.0;
         double longW = sum != null ? sum.longWindow : 0.0;
         double veryLongW = sum != null ? sum.veryLongWindow : 0.0;
@@ -77,9 +81,13 @@ public class AcCommand implements CommandExecutor, TabCompleter {
                 + "ms, tps "
                 + String.format("%.1f", tps)
                 + ", latencyOK="
-                + latencyOK
+                + stable
                 + ", stabilityOK="
-                + stabilityOK
+                + stable
+                + ", limit="
+                + limit
+                + "ms, tpsGuard="
+                + String.format("%.1f", tpsGuard)
                 + ", max25="
                 + String.format("%.2f", shortW)
                 + ", max100="

--- a/src/main/java/com/modernac/config/ConfigManager.java
+++ b/src/main/java/com/modernac/config/ConfigManager.java
@@ -6,14 +6,9 @@ import org.bukkit.configuration.file.FileConfiguration;
 
 public class ConfigManager {
   private final FileConfiguration config;
-  private int minFamiliesForBan;
 
   public ConfigManager(ModernACPlugin plugin) {
     this.config = plugin.getConfig();
-    this.minFamiliesForBan =
-        this.config.getInt(
-            "punishment.min_families_for_ban",
-            this.config.getInt("punishment.min-families-for-ban", 2));
   }
 
   public String getKickCommand() {
@@ -136,16 +131,20 @@ public class ConfigManager {
     return config.getBoolean("logging.alerts.to_file", true);
   }
 
-  public int getMinFamiliesForBan() {
-    return minFamiliesForBan;
-  }
-
   public int getMinIndependentFamiliesForAction() {
-    return config.getInt("policy.min_independent_families_for_action", 2);
+    return config.getInt(
+        "policy.min_independent_families_for_action",
+        config.getInt(
+            "punishment.min_families_for_ban",
+            config.getInt("punishment.min-families-for-ban", 2)));
   }
 
   public boolean isMultiWindowConfirmationRequired() {
-    return config.getBoolean("policy.require_multi_window_confirmation", true);
+    return config.getBoolean(
+        "policy.require_multi_window_confirmation",
+        config.getBoolean(
+            "punishment.require_multi_window_confirmation",
+            config.getBoolean("punishment.require-multi-window-confirmation", true)));
   }
 
   public PunishmentTier getCheckTier(String checkName) {

--- a/src/main/java/com/modernac/engine/DetectionEngine.java
+++ b/src/main/java/com/modernac/engine/DetectionEngine.java
@@ -5,6 +5,7 @@ import com.modernac.checks.Check;
 import com.modernac.config.ConfigManager;
 import com.modernac.engine.AlertEngine.AlertDetail;
 import com.modernac.manager.PunishmentTier;
+import com.modernac.util.LatencyGuard;
 import java.util.EnumMap;
 import java.util.Locale;
 import java.util.Map;
@@ -56,9 +57,7 @@ public class DetectionEngine {
     PlayerRecord record = records.computeIfAbsent(uuid, u -> new PlayerRecord());
     FamilyRecord fam = record.families.computeIfAbsent(result.getFamily(), f -> new FamilyRecord());
     double prev = fam.windowScores.getOrDefault(result.getWindow(), 0.0);
-    fam.windowScores.put(result.getWindow(), Math.max(prev, result.getEvidenceScore()));
-    fam.latencyOK &= result.isLatencyOK();
-    fam.stabilityOK &= result.isStabilityOK();
+      fam.windowScores.put(result.getWindow(), Math.max(prev, result.getEvidenceScore()));
     ConfigManager cfg = plugin.getConfigManager();
     PunishmentTier tier = cfg.getCheckTier(check.getName());
     if (tier.ordinal() < fam.tier.ordinal()) {
@@ -68,20 +67,20 @@ public class DetectionEngine {
     int ping = pd != null ? pd.getCachedPing() : -1;
     double[] tpsArr = Bukkit.getTPS();
     double tps = tpsArr.length > 0 && Double.isFinite(tpsArr[0]) ? tpsArr[0] : 20.0;
-    EvalOutcome outcome = evaluate(uuid, record, ping, tps);
-    boolean pingKnown = ping > 0 && ping <= 180;
-    boolean tpsOK = tps >= 18.0;
-    boolean alertEligible =
-        pingKnown
-            && tpsOK
-            && outcome.families >= cfg.getMinFamiliesForBan()
-            && (!cfg.isMultiWindowConfirmationRequired() || outcome.windows >= 2)
-            && outcome.highest != null
-            && (outcome.highest == PunishmentTier.HIGH
-                || outcome.highest == PunishmentTier.CRITICAL);
-    if (!pingKnown || !tpsOK) {
-      outcome.punish = false;
-    }
+      EvalOutcome outcome = evaluate(uuid, record, ping, tps);
+      boolean stable =
+          ping > 0
+              && LatencyGuard.isStable(ping, tps, cfg.getUnstableConnectionLimit(), cfg.getTpsSoftGuard());
+      boolean alertEligible =
+          stable
+              && outcome.families >= cfg.getMinIndependentFamiliesForAction()
+              && (!cfg.isMultiWindowConfirmationRequired() || outcome.windows >= 2)
+              && outcome.highest != null
+              && (outcome.highest == PunishmentTier.HIGH
+                  || outcome.highest == PunishmentTier.CRITICAL);
+      if (!stable) {
+        outcome.punish = false;
+      }
     if (alertEligible) {
       double conf = outcome.highest == PunishmentTier.CRITICAL ? 1.0 : 0.9;
       AlertDetail detail =
@@ -212,16 +211,24 @@ public class DetectionEngine {
     double shortMax = 0.0;
     double longMax = 0.0;
     double veryLongMax = 0.0;
-    boolean latencyOK = true;
-    boolean stabilityOK = true;
     for (FamilyRecord fam : record.families.values()) {
       shortMax = Math.max(shortMax, fam.windowScores.getOrDefault(Window.SHORT, 0.0));
       longMax = Math.max(longMax, fam.windowScores.getOrDefault(Window.LONG, 0.0));
       veryLongMax = Math.max(veryLongMax, fam.windowScores.getOrDefault(Window.VERY_LONG, 0.0));
-      latencyOK &= fam.latencyOK;
-      stabilityOK &= fam.stabilityOK;
     }
-    return new DetectionSummary(latencyOK, stabilityOK, shortMax, longMax, veryLongMax);
+    int ping = -1;
+    com.modernac.player.PlayerData pd = plugin.getCheckManager().getPlayerData(uuid);
+    if (pd != null) {
+      ping = pd.getCachedPing();
+    }
+    double[] tpsArr = org.bukkit.Bukkit.getTPS();
+    double tps = tpsArr.length > 0 && Double.isFinite(tpsArr[0]) ? tpsArr[0] : 20.0;
+    ConfigManager cfg = plugin.getConfigManager();
+    boolean stable =
+        ping > 0
+            && LatencyGuard.isStable(
+                ping, tps, cfg.getUnstableConnectionLimit(), cfg.getTpsSoftGuard());
+    return new DetectionSummary(stable, stable, shortMax, longMax, veryLongMax);
   }
 
   public static class DetectionSummary {
@@ -250,10 +257,8 @@ public class DetectionEngine {
     PunishmentTier currentTier;
   }
 
-  private static class FamilyRecord {
-    final Map<Window, Double> windowScores = new EnumMap<>(Window.class);
-    boolean latencyOK = true;
-    boolean stabilityOK = true;
-    PunishmentTier tier = PunishmentTier.MEDIUM;
+    private static class FamilyRecord {
+      final Map<Window, Double> windowScores = new EnumMap<>(Window.class);
+      PunishmentTier tier = PunishmentTier.MEDIUM;
+    }
   }
-}

--- a/src/main/java/com/modernac/manager/CheckManager.java
+++ b/src/main/java/com/modernac/manager/CheckManager.java
@@ -7,6 +7,8 @@ import com.modernac.checks.combat.CombatCheckFactory;
 import com.modernac.checks.latency.LatencyCheckFactory;
 import com.modernac.checks.misc.MiscCheckFactory;
 import com.modernac.checks.signatures.SignatureCheckFactory;
+import com.modernac.config.ConfigManager;
+import com.modernac.util.LatencyGuard;
 import com.modernac.logging.DetectionLogger;
 import com.modernac.player.PlayerData;
 import com.modernac.player.RotationData;
@@ -96,6 +98,9 @@ public class CheckManager {
       double[] tpsArr = org.bukkit.Bukkit.getTPS();
       double tps =
           tpsArr.length > 0 && Double.isFinite(tpsArr[0]) ? tpsArr[0] : 20.0;
+      ConfigManager cfg = plugin.getConfigManager();
+      boolean stable =
+          ping > 0 && LatencyGuard.isStable(ping, tps, cfg.getUnstableConnectionLimit(), cfg.getTpsSoftGuard());
       org.bukkit.entity.Player player = org.bukkit.Bukkit.getPlayer(uuid);
       org.bukkit.entity.Entity target = data.getLastTarget();
       processAim =
@@ -109,9 +114,7 @@ public class CheckManager {
               && !player.isHandRaised()
               && player.getOpenInventory().getType()
                   == org.bukkit.event.inventory.InventoryType.CRAFTING
-              && ping > 0
-              && ping <= 180
-              && tps >= 18.0
+              && stable
               && Double.isFinite(rot.getYawChange());
     }
     final boolean aimOk = processAim;

--- a/src/main/java/com/modernac/util/LatencyGuard.java
+++ b/src/main/java/com/modernac/util/LatencyGuard.java
@@ -1,0 +1,13 @@
+package com.modernac.util;
+
+public final class LatencyGuard {
+  private LatencyGuard() {}
+
+  public static boolean isStable(int pingMs, double tps, int pingLimitMs, double tpsSoft) {
+    return pingMs <= pingLimitMs && tps >= tpsSoft;
+  }
+
+  public static boolean shouldSkip(int pingMs, double tps, int pingLimitMs, double tpsSoft) {
+    return !isStable(pingMs, tps, pingLimitMs, tpsSoft);
+  }
+}


### PR DESCRIPTION
## Summary
- centralize ping/TPS gate in `LatencyGuard`
- expose latency limits in `/ac info` and unify summary stability check
- update config to new `policy.*` keys with fallback compatibility

## Testing
- `mvn -o -DskipTests package` *(fails: Cannot access central (https://repo.maven.apache.org/maven2) in offline mode and the artifact org.apache.maven.plugins:maven-resources-plugin:jar:3.3.1 has not been downloaded)*


------
https://chatgpt.com/codex/tasks/task_e_689db15d43648325a118c64e46135a35