### PR TITLE
Implement lag compensator and diagnostics

### DIFF
--- a/src/main/java/com/modernac/ModernACPlugin.java
+++ b/src/main/java/com/modernac/ModernACPlugin.java
@@ -57,13 +57,18 @@ public class ModernACPlugin extends JavaPlugin {
     this.lagCompensator =
         new LagCompensator(
             configManager.isLagCompEnabled(),
-            configManager.getLagCompAlpha(),
+            configManager.getLagAlpha(),
+            configManager.getLagJitterAlpha(),
             configManager.getLagCompDtBase(),
             configManager.getLagCompDtMin(),
             configManager.getLagCompDtMax(),
             configManager.getLagCompYawRelaxPerJitter(),
             configManager.getUnstableConnectionLimit(),
-            configManager.getTpsSoftGuard());
+            configManager.getTpsSoftGuard(),
+            configManager.getLagStableRtt(),
+            configManager.getLagStableJitter(),
+            configManager.getLagStableTps(),
+            configManager.getLagBackfillMs());
 
     PacketEvents.getAPI().init();
     // Регистрируем 2.9.x слушатель
@@ -174,13 +179,18 @@ public class ModernACPlugin extends JavaPlugin {
     this.lagCompensator =
         new LagCompensator(
             configManager.isLagCompEnabled(),
-            configManager.getLagCompAlpha(),
+            configManager.getLagAlpha(),
+            configManager.getLagJitterAlpha(),
             configManager.getLagCompDtBase(),
             configManager.getLagCompDtMin(),
             configManager.getLagCompDtMax(),
             configManager.getLagCompYawRelaxPerJitter(),
             configManager.getUnstableConnectionLimit(),
-            configManager.getTpsSoftGuard());
+            configManager.getTpsSoftGuard(),
+            configManager.getLagStableRtt(),
+            configManager.getLagStableJitter(),
+            configManager.getLagStableTps(),
+            configManager.getLagBackfillMs());
   }
 
   public void exemptPlayer(UUID uuid, long durationMs) {

--- a/src/main/java/com/modernac/commands/AcCommand.java
+++ b/src/main/java/com/modernac/commands/AcCommand.java
@@ -194,6 +194,35 @@ public class AcCommand implements CommandExecutor, TabCompleter {
                 false);
         sender.sendMessage(ChatColor.GREEN + "Dev alert queued for " + target.getName());
         return true;
+      case "lag":
+        if (!sender.hasPermission("ac.command.lag")) {
+          sender.sendMessage(plugin.getMessageManager().getMessage("commands.no_permission"));
+          return true;
+        }
+        if (args.length < 2) {
+          sender.sendMessage(plugin.getMessageManager().getMessage("commands.usage"));
+          return true;
+        }
+        target = Bukkit.getOfflinePlayer(args[1]);
+        if (target == null || (target.getName() == null && !target.isOnline())) {
+          sender.sendMessage(plugin.getMessageManager().getMessage("commands.player_not_found"));
+          return true;
+        }
+        LagCompensator.LagContext ctxLag =
+            plugin.getLagCompensator().estimate(target.getUniqueId());
+        sender.sendMessage(
+            ChatColor.YELLOW
+                + "Lag for "
+                + target.getName()
+                + ": rtt="
+                + ctxLag.rttMs
+                + "ms, jitter="
+                + String.format("%.1f", ctxLag.jitterMs)
+                + "ms, tps="
+                + String.format("%.1f", ctxLag.tps)
+                + ", stable="
+                + ctxLag.stable);
+        return true;
       default:
         sender.sendMessage(plugin.getMessageManager().getMessage("commands.usage"));
         return true;
@@ -204,7 +233,8 @@ public class AcCommand implements CommandExecutor, TabCompleter {
   public List<String> onTabComplete(
       CommandSender sender, Command command, String alias, String[] args) {
     if (args.length == 1) {
-      return Arrays.asList("info", "status", "inspect", "debug", "exempt", "reload", "devfake");
+      return Arrays.asList(
+          "info", "status", "inspect", "debug", "exempt", "reload", "devfake", "lag");
     }
     if (args.length == 2
         && (args[0].equalsIgnoreCase("info")
@@ -212,7 +242,8 @@ public class AcCommand implements CommandExecutor, TabCompleter {
             || args[0].equalsIgnoreCase("debug")
             || args[0].equalsIgnoreCase("exempt")
             || args[0].equalsIgnoreCase("inspect")
-            || args[0].equalsIgnoreCase("devfake"))) {
+            || args[0].equalsIgnoreCase("devfake")
+            || args[0].equalsIgnoreCase("lag"))) {
       List<String> names = new ArrayList<>();
       for (Player p : Bukkit.getOnlinePlayers()) {
         names.add(p.getName());

--- a/src/main/java/com/modernac/config/ConfigManager.java
+++ b/src/main/java/com/modernac/config/ConfigManager.java
@@ -51,6 +51,30 @@ public class ConfigManager {
     return config.getDouble("lagcomp.yawRelaxPerJitterMs", 0.00025D);
   }
 
+  public double getLagAlpha() {
+    return config.getDouble("lag.alpha", 0.2D);
+  }
+
+  public double getLagJitterAlpha() {
+    return config.getDouble("lag.jitter.alpha", 0.2D);
+  }
+
+  public int getLagStableRtt() {
+    return config.getInt("lag.stable.rtt", 160);
+  }
+
+  public int getLagStableJitter() {
+    return config.getInt("lag.stable.jitter", 25);
+  }
+
+  public double getLagStableTps() {
+    return config.getDouble("lag.stable.tps", 19.0D);
+  }
+
+  public long getLagBackfillMs() {
+    return config.getLong("lag.backfill.ms", 75L);
+  }
+
   public boolean isExperimentalDetections() {
     return config.getBoolean("checks.experimental_detections", false);
   }

--- a/src/main/java/com/modernac/listener/PacketListenerImpl.java
+++ b/src/main/java/com/modernac/listener/PacketListenerImpl.java
@@ -68,6 +68,8 @@ public class PacketListenerImpl extends SimplePacketListenerAbstract {
     double pitchChange = Math.abs(pitch - lastPitchVal);
     lastYaw.put(uuid, yaw);
     lastPitch.put(uuid, pitch);
-    manager.handle(uuid, new RotationData(yawChange, pitchChange));
+    var ctx = plugin.getLagCompensator().estimate(uuid);
+    long corrected = System.currentTimeMillis() - ctx.oneWayMs;
+    manager.handle(uuid, new RotationData(yawChange, pitchChange, corrected, ctx.stable));
   }
 }

--- a/src/main/java/com/modernac/manager/CheckManager.java
+++ b/src/main/java/com/modernac/manager/CheckManager.java
@@ -105,7 +105,8 @@ public class CheckManager {
               && !player.isHandRaised()
               && player.getOpenInventory().getType()
                   == org.bukkit.event.inventory.InventoryType.CRAFTING
-              && Double.isFinite(rot.getYawChange());
+              && Double.isFinite(rot.getYawChange())
+              && rot.isStable();
     }
     final boolean aimOk = processAim;
     executor.execute(

--- a/src/main/java/com/modernac/net/LagCompensator.java
+++ b/src/main/java/com/modernac/net/LagCompensator.java
@@ -16,8 +16,16 @@ public final class LagCompensator {
     public final int dtRotAimMs;
     public final double yawRelax;
     public final boolean soft;
+    public final boolean stable;
 
-    LagContext(int rttMs, double jitterMs, double tps, int dtRotAimMs, double yawRelax, boolean soft) {
+    LagContext(
+        int rttMs,
+        double jitterMs,
+        double tps,
+        int dtRotAimMs,
+        double yawRelax,
+        boolean soft,
+        boolean stable) {
       this.rttMs = rttMs;
       this.jitterMs = jitterMs;
       this.tps = tps;
@@ -25,6 +33,7 @@ public final class LagCompensator {
       this.dtRotAimMs = dtRotAimMs;
       this.yawRelax = yawRelax;
       this.soft = soft;
+      this.stable = stable;
     }
   }
 
@@ -37,31 +46,46 @@ public final class LagCompensator {
 
   private final ConcurrentHashMap<UUID, State> map = new ConcurrentHashMap<>();
   private final boolean enabled;
-  private final double alpha;
+  private final double alphaRtt;
+  private final double alphaJitter;
   private final int dtBase;
   private final int dtMin;
   private final int dtMax;
   private final double yawRelaxPerJitter;
   private final int unstableLimitMs;
   private final double tpsSoftGuard;
+  private final int stableRttMs;
+  private final double stableJitterMs;
+  private final double stableTps;
+  private final long backfillMs;
 
   public LagCompensator(
       boolean enabled,
-      double alpha,
+      double alphaRtt,
+      double alphaJitter,
       int dtBase,
       int dtMin,
       int dtMax,
       double yawRelaxPerJitter,
       int unstableLimitMs,
-      double tpsSoftGuard) {
+      double tpsSoftGuard,
+      int stableRttMs,
+      double stableJitterMs,
+      double stableTps,
+      long backfillMs) {
     this.enabled = enabled;
-    this.alpha = alpha;
+    this.alphaRtt = alphaRtt;
+    this.alphaJitter = alphaJitter;
     this.dtBase = dtBase;
     this.dtMin = dtMin;
     this.dtMax = dtMax;
     this.yawRelaxPerJitter = yawRelaxPerJitter;
     this.unstableLimitMs = unstableLimitMs;
     this.tpsSoftGuard = tpsSoftGuard;
+    this.stableRttMs = stableRttMs;
+    this.stableJitterMs = stableJitterMs;
+    this.stableTps = stableTps;
+    this.backfillMs = backfillMs;
   }
 
   public void sample(UUID id, int rttMs, double tps) {
@@ -73,16 +97,16 @@ public final class LagCompensator {
       if (st.rttEwma < 0) st.rttEwma = rttMs;
       double prev = st.lastRtt < 0 ? rttMs : st.lastRtt;
       double jitter = Math.abs(rttMs - prev);
-      st.jitterEwma = (1 - alpha) * st.jitterEwma + alpha * jitter;
-      st.rttEwma = (1 - alpha) * st.rttEwma + alpha * rttMs;
+      st.jitterEwma = (1 - alphaJitter) * st.jitterEwma + alphaJitter * jitter;
+      st.rttEwma = (1 - alphaRtt) * st.rttEwma + alphaRtt * rttMs;
       st.lastRtt = rttMs;
     }
-    st.tpsEwma = (1 - alpha) * st.tpsEwma + alpha * tps;
+    st.tpsEwma = (1 - alphaRtt) * st.tpsEwma + alphaRtt * tps;
   }
 
   public LagContext estimate(UUID id) {
     if (!enabled) {
-      return new LagContext(0, 0.0, 20.0, dtBase, 0.0, false);
+      return new LagContext(0, 0.0, 20.0, dtBase, 0.0, false, true);
     }
     State st = map.computeIfAbsent(id, k -> new State());
     int rtt = (int) Math.round(st.rttEwma < 0 ? 0 : st.rttEwma);
@@ -91,7 +115,21 @@ public final class LagCompensator {
     int dt = clamp((int) Math.round(dtBase + jitter * 0.5 + rtt * 0.25), dtMin, dtMax);
     double yawRelax = jitter * yawRelaxPerJitter;
     boolean soft = (rtt >= unstableLimitMs) || (tps < tpsSoftGuard);
-    return new LagContext(rtt, jitter, tps, dt, yawRelax, soft);
+    boolean stable = rtt < stableRttMs && jitter < stableJitterMs && tps >= stableTps;
+    return new LagContext(rtt, jitter, tps, dt, yawRelax, soft, stable);
+  }
+
+  public boolean isStable(UUID id) {
+    return estimate(id).stable;
+  }
+
+  public long correctedTime(UUID id, long now) {
+    if (!enabled) {
+      return now;
+    }
+    State st = map.computeIfAbsent(id, k -> new State());
+    int rtt = (int) Math.round(st.rttEwma < 0 ? 0 : st.rttEwma);
+    return now - Math.max(0, rtt / 2);
   }
 
   private static int clamp(int v, int lo, int hi) {

--- a/src/main/java/com/modernac/player/PlayerData.java
+++ b/src/main/java/com/modernac/player/PlayerData.java
@@ -43,7 +43,9 @@ public class PlayerData {
   }
 
   public void recordRotation(RotationData rot) {
-    baseline.update(rot.getYawChange(), rot.getPitchChange());
+    if (rot.isStable()) {
+      baseline.update(rot.getYawChange(), rot.getPitchChange());
+    }
   }
 
   public void markHit(boolean targetIsPlayer, UUID targetId, Vector unitToTarget) {

--- a/src/main/java/com/modernac/player/RotationData.java
+++ b/src/main/java/com/modernac/player/RotationData.java
@@ -3,10 +3,14 @@ package com.modernac.player;
 public class RotationData {
   private final double yawChange;
   private final double pitchChange;
+  private final long serverTime;
+  private final boolean stable;
 
-  public RotationData(double yawChange, double pitchChange) {
+  public RotationData(double yawChange, double pitchChange, long serverTime, boolean stable) {
     this.yawChange = yawChange;
     this.pitchChange = pitchChange;
+    this.serverTime = serverTime;
+    this.stable = stable;
   }
 
   public double getYawChange() {
@@ -15,5 +19,13 @@ public class RotationData {
 
   public double getPitchChange() {
     return pitchChange;
+  }
+
+  public long getServerTime() {
+    return serverTime;
+  }
+
+  public boolean isStable() {
+    return stable;
   }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -14,6 +14,17 @@ lagcomp:
   dtMax: 90
   yawRelaxPerJitterMs: 0.00025
 
+lag:
+  alpha: 0.2
+  jitter:
+    alpha: 0.2
+  stable:
+    rtt: 160
+    jitter: 25
+    tps: 19.0
+  backfill:
+    ms: 75
+
 checks:
   experimental_detections: true
   combat_tolerance: "normal"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -10,7 +10,7 @@ commands:
     description: AntiCheat main command
     aliases: [anticheat]
     permission: ac.use
-    usage: /ac <info|debug|exempt|reload|devfake|status|inspect>
+    usage: /ac <info|debug|exempt|reload|devfake|status|inspect|lag>
 permissions:
   ac.use:
     description: Allows use of /ac command
@@ -29,6 +29,9 @@ permissions:
     default: op
   ac.command.reload:
     description: Use /ac reload
+    default: op
+  ac.command.lag:
+    description: Use /ac lag
     default: op
   modernac.dev:
     description: Access developer commands

--- a/src/test/java/com/modernac/net/LagCompensatorTest.java
+++ b/src/test/java/com/modernac/net/LagCompensatorTest.java
@@ -1,0 +1,37 @@
+package com.modernac.net;
+
+import static org.junit.Assert.*;
+
+import java.util.UUID;
+import org.junit.Test;
+
+public class LagCompensatorTest {
+  @Test
+  public void testSmoothingAndStability() {
+    LagCompensator comp =
+        new LagCompensator(
+            true,
+            0.2,
+            0.2,
+            35,
+            25,
+            90,
+            0.0,
+            1000,
+            18.0,
+            160,
+            25.0,
+            19.0,
+            75);
+    UUID id = UUID.randomUUID();
+    for (int i = 0; i < 5; i++) {
+      comp.sample(id, 100, 20.0);
+    }
+    LagCompensator.LagContext ctx = comp.estimate(id);
+    assertTrue(ctx.stable);
+    comp.sample(id, 400, 20.0);
+    LagCompensator.LagContext ctx2 = comp.estimate(id);
+    assertFalse(ctx2.stable);
+    assertTrue(ctx2.rttMs > ctx.rttMs);
+  }
+}


### PR DESCRIPTION
## Summary
- add configurable LagCompensator with RTT/jitter smoothing and stability window
- correct incoming rotation timestamps and gate checks on stable network conditions
- expose `/ac lag` command for per-player latency diagnostics

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*
- `mvn -q -DskipTests=false test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_689e03e51f1c8325ad933c5cda1c212b